### PR TITLE
Auto discover smarter

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ view/table being replicated.
   export TAP_SNOWFLAKE_WAREHOUSE=<snowflake-warehouse>
 ```
 
-NOTE: User must have permission to create/drop schema (TAP_SNOWFLAKE_TEST), create/drop table, insert into those tables
+NOTE: User must have permission to create/drop schema (TAP_SNOWFLAKE_TEST), create/drop table, insert into those tables. DEG's implementation uses DATA_DEG_TEST.TAP_SNOWFLAKE_TEST - credentials are in the 1Pass vault.
 
 2. Install python dependencies in a virtual env and run unit and integration tests
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ source table directly corresponds to a Singer stream.
 The two ways to replicate a given table are `FULL_TABLE` and `INCREMENTAL`.
 
 Note: Discovery does not include these values in the output catalog, you must add them to
-the metadata of the configured tables.
+the metadata of the configured tables. Alternatively if you run the tap without a catalog then
+it will auto-discover and default to full table replication unless overridden by config metadata.
 
 ### Full Table
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ or
    }
    ```
 
+Optional Metadata can be provided in the config to define the syncing strategy for tables so that auto discovery creates a fully configured catalog.
+   ```json
+   {
+      "account": "rtxxxxx.eu-central-1",
+      "dbname": "database_name",
+      "user": "my_user",
+      "password": "password",
+      "warehouse": "my_virtual_warehouse",
+      "tables": "db.schema.table1,db.schema.table2",
+      "metadata": {
+          "db.schema.table1": {
+              "table-key-properties": ["key1"],
+              "replication-key": "column1",
+              "replication-method": "INCREMENTAL",
+              "selected": true
+          }
+      }
+   }
+   ```
+
 **Note**: `tables` is a mandatory parameter as well to avoid long running catalog discovery process.
 Please specify fully qualified table and view names and only that ones that you need to extract otherwise you can
 end up with very long running discovery mode of this tap. Discovery mode is analysing table structures but

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pipelinewise-singer-python==1.*
+pipelinewise-singer-python==1.2.0
 snowflake-connector-python[pandas]==2.3.7
 pendulum==1.2.0
 python-dateutil>=2.1,<2.8.2

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -234,7 +234,7 @@ def discover_catalog(snowflake_conn, config):
             md_map = metadata.write(md_map, (), 'row-count', row_count)
             md_map = metadata.write(md_map, (), 'is-view', is_view)
             # check config to see if there was optional metadata defined already
-            full_table_name = f'{table_schema}.{table_name}'.upper()
+            full_table_name = f'{catalog}.{table_schema}.{table_name}'.upper()
             if config_meta and full_table_name in config_meta:
                 table_meta = config_meta.get(full_table_name)
                 for meta_key, meta_value in table_meta.items():

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -104,9 +104,13 @@ def schema_for_column(c):
     return result
 
 
-def create_column_metadata(cols):
+def create_column_metadata(cols, select_all):
     mdata = {}
     mdata = metadata.write(mdata, (), 'selected-by-default', False)
+    if select_all:
+        mdata = metadata.write(mdata, (), 'selected-by-default', True)
+        mdata = metadata.write(mdata, (), 'selected', True)
+
     for c in cols:
         schema = schema_for_column(c)
         mdata = metadata.write(mdata,
@@ -176,7 +180,13 @@ def config_meta_parser(config):
     return {table.upper(): data for table, data in config.get('metadata', {}).items()}
 
 
-def discover_catalog(snowflake_conn, config):
+def select_all_fields_in_streams(catalog):
+    for stream in catalog.streams:
+        for meta in stream.metadata:
+            meta['metadata'].update({'selected': True})
+
+
+def discover_catalog(snowflake_conn, config, select_all=False):
     """Returns a Catalog describing the structure of the database."""
     tables = config.get('tables').split(',')
     sql_columns = get_table_columns(snowflake_conn, tables)
@@ -217,7 +227,7 @@ def discover_catalog(snowflake_conn, config):
         (table_catalog, table_schema, table_name) = k
         schema = Schema(type='object',
                         properties={c.column_name: schema_for_column(c) for c in cols})
-        md = create_column_metadata(cols)
+        md = create_column_metadata(cols, select_all)
         md_map = metadata.to_map(md)
 
         md_map = metadata.write(md_map, (), 'database-name', table_catalog)
@@ -233,6 +243,11 @@ def discover_catalog(snowflake_conn, config):
             is_view = table_info[table_catalog][table_schema][table_name]['is_view']
             md_map = metadata.write(md_map, (), 'row-count', row_count)
             md_map = metadata.write(md_map, (), 'is-view', is_view)
+            # if select_all is True set replication-method default to FULL_TABLE, will be overriden if
+            # user defined INCREMENTAL in the config metadata
+            if select_all:
+                md_map = metadata.write(md_map, (), 'replication-method', 'FULL_TABLE')
+
             # check config to see if there was optional metadata defined already
             full_table_name = f'{catalog}.{table_schema}.{table_name}'.upper()
             if config_meta and full_table_name in config_meta:
@@ -502,7 +517,10 @@ def main_impl():
         state = args.state or {}
         do_sync(snowflake_conn, args.config, catalog, state)
     else:
-        LOGGER.info('No properties were selected')
+        # do auto sync
+        catalog = discover_catalog(snowflake_conn, args.config, select_all=True)
+        state = args.state or {}
+        do_sync(snowflake_conn, args.config, catalog, state)
 
 
 def main():

--- a/tests/integration/test_tap_snowflake.py
+++ b/tests/integration/test_tap_snowflake.py
@@ -16,7 +16,7 @@ except ImportError:
 
 LOGGER = singer.get_logger('tap_snowflake_tests')
 
-SCHEMA_NAME = 'tap_snowflake_test'
+SCHEMA_NAME = 'TAP_SNOWFLAKE_TEST'
 
 DB_NAME = os.environ['TAP_SNOWFLAKE_DBNAME']
 
@@ -300,7 +300,7 @@ class TestTypeMapping(unittest.TestCase):
 
         stream = catalog.streams[0]
         stream_metadata = stream.to_dict().get('metadata')[0].get('metadata')
-        self.assertCountEqual(
+        self.assertEqual(
             stream_metadata,
             {
                 'table-key-properties': ['keys'],
@@ -322,7 +322,7 @@ class TestTypeMapping(unittest.TestCase):
         # table should be discovered
         stream = catalog.streams[0]
         stream_metadata = stream.to_dict().get('metadata')[0].get('metadata')
-        self.assertCountEqual(
+        self.assertEqual(
             stream_metadata,
             {
                 'selected-by-default': False,
@@ -330,6 +330,26 @@ class TestTypeMapping(unittest.TestCase):
                 'schema-name': f'{SCHEMA_NAME}',
                 'row-count': 0,
                 'is-view': False,
+            }
+        )
+
+    def test_discover_catalog_select_all(self):
+        """Validate if discovering catalog select-all works"""
+        catalog = test_utils.discover_catalog(self.snowflake_conn, {'tables': f'{SCHEMA_NAME}.empty_table_1'}, select_all=True)
+
+        # table should be discovered
+        stream = catalog.streams[0]
+        stream_metadata = stream.to_dict().get('metadata')[0].get('metadata')
+        self.assertEqual(
+            stream_metadata,
+            {
+                'replication-method': 'FULL_TABLE',
+                'selected-by-default': True,
+                'database-name': f'{DB_NAME}',
+                'schema-name': f'{SCHEMA_NAME}',
+                'row-count': 0,
+                'is-view': False,
+                'selected': True
             }
         )
 

--- a/tests/integration/test_tap_snowflake.py
+++ b/tests/integration/test_tap_snowflake.py
@@ -282,19 +282,20 @@ class TestTypeMapping(unittest.TestCase):
 
     def test_discover_catalog_with_strategy_defined(self):
         """Validate if discovering catalog adds the sync strategy and incrementing col if provided"""
-        catalog = test_utils.discover_catalog(
-            self.snowflake_conn,
-            {
-                'tables': f'{SCHEMA_NAME}.empty_table_1',
+        config = {
+                'tables': f'{DB_NAME}.{SCHEMA_NAME}.empty_table_1',
                 'metadata': {
-                    f'{SCHEMA_NAME}.empty_table_1': {
+                    f'{DB_NAME}.{SCHEMA_NAME}.empty_table_1': {
                         'table-key-properties': ['keys'],
                         'replication-key': 'column1',
                         'replication-method': 'INCREMENTAL',
                         'selected': True
                     }
                 }
-            }
+        }
+        catalog = test_utils.discover_catalog(
+            self.snowflake_conn,
+            config
         )
 
         stream = catalog.streams[0]

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -34,8 +34,8 @@ def get_test_connection():
     return snowflake_conn
 
 
-def discover_catalog(snowflake_conn, config):
-    catalog = tap_snowflake.discover_catalog(snowflake_conn, config)
+def discover_catalog(snowflake_conn, config, select_all=False):
+    catalog = tap_snowflake.discover_catalog(snowflake_conn, config, select_all=select_all)
     streams = []
 
     for stream in catalog.streams:


### PR DESCRIPTION
- builds on PR https://github.com/bonobos/tap-snowflake/pull/4

- Adds functionality to set sync strategy metadata in the config file vs the catalog. This enables discovery to be fully automated compared to previously where no strategy and selected=false was the default
- If no catalog is defined then auto discovery is run and default sync strategy is set to FULL_TABLE (can be overridden by config metadata, explained above) and selected=true for all. This means new columns are pulled in without changing anything manually.
- backwards compatible