### PR TITLE
remove generic metadata config and put rolling-lookback at top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,21 +127,13 @@ is invoked.
 
 Additionally, the full table sync can be configured to use a look back window to limit the size of the data set being synced. The look period is from the current time minus the configured rolling_lookback period. `time_unit` is any date or time part [supported by snowflake](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts) and the `time_amount` is the positive integer of time units to look backwards. 
 ```
-  "metadata": {
-    "replication-method": "FULL_TABLE",
-    "selected-by-default": false,
-    "database-name": "DB_123",
-    "schema-name": "SCHEMA_456",
-    "row-count": 0,
-    "is-view": false,
-    "selected": true,
-    "rolling_lookback": {
-      "time_unit": "day",
-      "time_amount": "7",
-      "time_column": "DATE_OR_TS_COL_NAME"
-    }
-  }
-
+   "rolling_lookback": {
+      "db-schema-table": {
+         "time_unit": "day",
+         "time_amount": "7",
+         "time_column": "DATE_OR_TS_COL_NAME"
+      }
+   }
 ```
 
 ### Incremental

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -179,6 +179,11 @@ def get_table_columns(snowflake_conn, tables):
     return table_columns
 
 
+def config_meta_parser(config):
+    # make sure config table names are upper case
+    return {table.upper(): data for table, data in config.get('metadata', {}).items()}
+
+
 def select_all_fields_in_streams(catalog):
     for stream in catalog.streams:
         for meta in stream.metadata:
@@ -189,6 +194,7 @@ def discover_catalog(snowflake_conn, config, select_all=False):
     """Returns a Catalog describing the structure of the database."""
     tables = config.get('tables').split(',')
     sql_columns = get_table_columns(snowflake_conn, tables)
+    config_meta = config_meta_parser(config)
 
     table_info = {}
     columns = []
@@ -252,6 +258,13 @@ def discover_catalog(snowflake_conn, config, select_all=False):
             if rolling and full_table_name in rolling:
                 rolling_table_meta = rolling.get(full_table_name)
                 md_map = metadata.write(md_map, (), 'rolling-lookback', rolling_table_meta)
+
+            # check config to see if there was optional metadata defined already
+            full_table_name = f'{catalog}.{table_schema}.{table_name}'.upper()
+            if config_meta and full_table_name in config_meta:
+                table_meta = config_meta.get(full_table_name)
+                for meta_key, meta_value in table_meta.items():
+                    md_map = metadata.write(md_map, (), meta_key, meta_value)
 
             entry = CatalogEntry(
                 table=table_name,

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -179,11 +179,6 @@ def get_table_columns(snowflake_conn, tables):
     return table_columns
 
 
-def config_meta_parser(config):
-    # make sure config table names are upper case
-    return {table.upper(): data for table, data in config.get('metadata', {}).items()}
-
-
 def select_all_fields_in_streams(catalog):
     for stream in catalog.streams:
         for meta in stream.metadata:
@@ -194,7 +189,6 @@ def discover_catalog(snowflake_conn, config, select_all=False):
     """Returns a Catalog describing the structure of the database."""
     tables = config.get('tables').split(',')
     sql_columns = get_table_columns(snowflake_conn, tables)
-    config_meta = config_meta_parser(config)
 
     table_info = {}
     columns = []
@@ -252,12 +246,12 @@ def discover_catalog(snowflake_conn, config, select_all=False):
             if select_all:
                 md_map = metadata.write(md_map, (), 'replication-method', 'FULL_TABLE')
 
-            # check config to see if there was optional metadata defined already
-            full_table_name = f'{catalog}.{table_schema}.{table_name}'.upper()
-            if config_meta and full_table_name in config_meta:
-                table_meta = config_meta.get(full_table_name)
-                for meta_key, meta_value in table_meta.items():
-                    md_map = metadata.write(md_map, (), meta_key, meta_value)
+            # check config to see if there was optional rolling-lookback defined, inject into catalog if so
+            full_table_name = f'{catalog}-{table_schema}-{table_name}'.upper()
+            rolling = config.get('rolling-lookback')
+            if rolling and full_table_name in rolling:
+                rolling_table_meta = rolling.get(full_table_name)
+                md_map = metadata.write(md_map, (), 'rolling-lookback', rolling_table_meta)
 
             entry = CatalogEntry(
                 table=table_name,


### PR DESCRIPTION
This tap is run by meltano which has a feature to inject generic metadata into any tap catalog so we dont need this "metadata" config key anymore. We actually dont use config key anymore we just use the __METADATA meltano feature now.

The only problem with meltano's implementation is that it doesnt support our dictionary rolling lookback setting.

The rolling lookback is now a first class config key in the tap but is handled the same way as before, i.e. injecting it as metadata into the catalog.
