### PR TITLE
fix filter bug that sends boundary records more than once

### DIFF
--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -156,7 +156,7 @@ def generate_filter_sql(catalog_entry, bookmark_value):
             raise Exception('Lookback rolling window not supported for INCREMENTAL sync')
         replication_key = stream_metadata.get('replication-key')
         if replication_key and bookmark_value:
-            filter_sql += f' WHERE "{replication_key}" >= \'{bookmark_value}\' ORDER BY "{replication_key}" ASC'
+            filter_sql += f' WHERE "{replication_key}" > \'{bookmark_value}\' ORDER BY "{replication_key}" ASC'
         elif replication_key:
             filter_sql += f' ORDER BY "{replication_key}" ASC'
 


### PR DESCRIPTION
For example:
Run 1: Records through Aug 23 6PM Extracted. Bookmark -> Aug 23 6PM
Run 2: Records >= Aug 23 6PM Extracted and sent. The records with Update Timestamp exactly Aug 23 6PM are being sent twice.

I am correcting this boundary condition, so that in Run 1, the 6pm records are sent, and in Run 2 only records > 6PM are sent.